### PR TITLE
Use un-acknowledged write to frac reg for speed and stability

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,13 +6,14 @@ lib_sw_pll library change log
 
   * ADDED: Support for XCommon CMake build system
   * ADDED: Reset PI controller state API
-  * ADDED: Fixed (non phase-locked) clock PLL API
+  * ADDED: Fixed frequency (non phase-locked) clock PLL API
   * FIXED: Init resets PI controller state
   * FIXED: Now compiles from XC using XCommon
   * ADDED: Guard source code with __XS3A__ to allow library inclusion in non-
     xcore-ai projects
   * CHANGED: Reduce PLL initialisation stabilisation delay from 10 ms to 500 us
   * ADDED: Split SDM init function to allow separation across tiles
+  * FIXED: Use non-ACK write to PLL in SDM
 
 2.0.0
 -----

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,7 +13,7 @@ lib_sw_pll library change log
     xcore-ai projects
   * CHANGED: Reduce PLL initialisation stabilisation delay from 10 ms to 500 us
   * ADDED: Split SDM init function to allow separation across tiles
-  * FIXED: Use non-ACK write to PLL in SDM
+  * FIXED: Use non-ACK write to PLL in Sigma Delta Modulator
 
 2.0.0
 -----

--- a/lib_sw_pll/src/sw_pll_sdm.h
+++ b/lib_sw_pll/src/sw_pll_sdm.h
@@ -99,11 +99,11 @@ static inline uint32_t sw_pll_sdm_out_to_frac_reg(int32_t sdm_out){
  *          implements a method for doing this.
  *
  * \param this_tile    The ID of the xcore tile that is doing the write.
- * \param frac_val     16b signed input error value
+ * \param frac_val     32b register value
  */
 __attribute__((always_inline))
 static inline void sw_pll_write_frac_reg(tileref_t this_tile, uint32_t frac_val){
-    write_sswitch_reg(this_tile, XS1_SSWITCH_SS_APP_PLL_FRAC_N_DIVIDER_NUM, frac_val);
+    write_sswitch_reg_no_ack(this_tile, XS1_SSWITCH_SS_APP_PLL_FRAC_N_DIVIDER_NUM, frac_val);
 }
 
 


### PR DESCRIPTION
Fixes a lockup issue of SDM modulator when switch is busy and will improve execution time performance of inner loop.