### PR TITLE
Added fixed clock example

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,11 +4,13 @@ lib_sw_pll change log
 UNRELEASED
 ----------
 
+
   * ADDED:     Support for xcore-400 devices
   * ADDED:     sw_pll_tile_mask_t enum with named constants (SW_PLL_TILE_0,
     SW_PLL_TILE_1, SW_PLL_TILE_BOTH) for tile selection
   * ADDED:     sw_pll_result_t enum with error codes (SW_PLL_SUCCESS,
     SW_PLL_ERR_INVALID_TILE_MASK, SW_PLL_ERR_INVALID_FREQUENCY)
+  * ADDED:     Example application demonstating fixed frequency output (app_fixed_clock)
   * CHANGED:   Public PLL initialisation APIs sw_pll_app_pll_init(), sw_pll_lut_init(),
     sw_pll_sdm_init() and sw_pll_fixed_clock() now return sw_pll_result_t enum and take an
     additional tile_mask parameter of type sw_pll_tile_mask_t

--- a/README.rst
+++ b/README.rst
@@ -23,8 +23,8 @@ It supports both Look Up Table (LUT) and Sigma Delta Modulated (SDM) Digitally C
 Oscillators (DCO), a Phase Frequency Detector (PFD) and configurable Proportional Integral (PI)
 controllers which together form a hybrid Software/Hardware Phase Locked Loop (PLL).
 
-Examples are provided showing a master clock locking to a low frequency input reference clock and
-also to an I²S slave interface.
+Examples are provided showing a master clock locking to a low frequency input reference clock,
+an I²S slave interface, and generating fixed frequency clocks without phase locking.
 
 In addition, an API providing a range of fixed clocks supporting common master clock frequencies
 between 11.2896 MHz and 49.152 MHz is available in cases where phase locking is not required.
@@ -52,7 +52,7 @@ Known issues
 Development repo
 ****************
 
-* `lib_sw_pll <https://www.github.com/xmos/lib_sw_pll>`_
+* `lib_sw_pll <https://www.github.com/xmos/lib_sw_pll>`_ (https://www.github.com/xmos/lib_sw_pll)
 
 **************
 Required tools
@@ -76,5 +76,6 @@ Related application notes
 Support
 *******
 
-This package is supported by XMOS Ltd. Issues can be raised against the software at www.xmos.com/support
+This package is supported by XMOS Ltd. Issues can be raised against the software at
+`www.xmos.com/support <https://www.xmos.com/support>`_ or using GitHub `issues <https://github.com/xmos/lib_sw_pll/issues>`_.
 

--- a/doc/rst/sw_pll.rst
+++ b/doc/rst/sw_pll.rst
@@ -614,14 +614,27 @@ To build the applications, from an XTC command prompt run the following commands
     cmake -B build -G "Unix Makefiles"
     xmake -C build
 
-To run the firmware, first connect `LRCLK` and `BCLK` (connects the test clock output to the PLL
-reference input) and run one of the following commands.
-*app_simple_lut* or *app_simple_sdm* runs on the `XK-EVK-XU316` board,  *app_i2s_slave_lut*
-requires the `XK-VOICE-SQ66` board::
+To run the firmware, run one of the following commands.
 
+*app_fixed_clock* demonstrates the fixed clock API and requires no hardware connections.
+
+For *app_simple_lut* and *app_simple_sdm*, first connect `LRCLK` and `BCLK` (connects the test
+clock output to the PLL reference input).
+
+*app_fixed_clock*, *app_simple_lut*, and *app_simple_sdm* run on the `XK-EVK-XU316` board.
+*app_i2s_slave_lut* requires the `XK-VOICE-SQ66` board::
+
+    xrun --xscope app_fixed_clock/bin/app_fixed_clock.xe
     xrun --xscope app_simple_lut/bin/app_simple_lut.xe
     xrun --xscope app_simple_sdm/bin/app_simple_sdm.xe
     xrun --xscope app_i2s_slave_lut/bin/app_i2s_slave_lut.xe
+
+For `app_fixed_clock.xe`, the application demonstrates the `sw_pll_fixed_clock()` API
+by cycling the PLL output between 24.576 MHz and 0 Hz (disabled) with 5-second intervals.
+This example requires no hardware connections and can be observed by placing an oscilloscope
+probe on pin X1D11 (tile[1]). The pin will output a 24.576 MHz clock for 5 seconds, then
+be disabled (reverted to port control) for 5 seconds, repeating indefinitely. This demonstrates
+both enabling the PLL at a fixed frequency and powering it down.
 
 For `app_simple_lut.xe` and `app_simple_sdm.xe`, to see the PLL lock, put a oscilloscope probe on
 either `LRCLK`/`BCLK` (reference input) and another on `PORT_I2S_DAC_DATA` to see the

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,6 +1,7 @@
 cmake_minimum_required(VERSION 3.21)
 include($ENV{XMOS_CMAKE_PATH}/xcommon.cmake)
 project(lib_sw_pll_examples)
+add_subdirectory(app_fixed_clock)
 add_subdirectory(app_i2s_slave_lut)
 add_subdirectory(app_simple_lut)
 add_subdirectory(app_simple_sdm)

--- a/examples/app_fixed_clock/CMakeLists.txt
+++ b/examples/app_fixed_clock/CMakeLists.txt
@@ -1,0 +1,17 @@
+cmake_minimum_required(VERSION 3.21)
+include($ENV{XMOS_CMAKE_PATH}/xcommon.cmake)
+project(app_fixed_clock)
+
+set(APP_HW_TARGET           XK-EVK-XU316)
+
+include(${CMAKE_CURRENT_LIST_DIR}/../deps.cmake)
+
+set(APP_COMPILER_FLAGS      -Os
+                            -g
+                            -report)
+
+set(APP_XSCOPE_SRCS         src/config.xscope)
+
+set(XMOS_SANDBOX_DIR        ${CMAKE_CURRENT_LIST_DIR}/../../..)
+
+XMOS_REGISTER_APP()

--- a/examples/app_fixed_clock/src/config.xscope
+++ b/examples/app_fixed_clock/src/config.xscope
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- ======================================================= -->
+<!-- The 'ioMode' attribute on the xSCOPEconfig              -->
+<!-- element can take the following values:                  -->
+<!--   "none", "basic", "timed"                              -->
+<!--                                                         -->
+<!-- The 'type' attribute on Probe                           -->
+<!-- elements can take the following values:                 -->
+<!--   "STARTSTOP", "CONTINUOUS", "DISCRETE", "STATEMACHINE" -->
+<!--                                                         -->
+<!-- The 'datatype' attribute on Probe                       -->
+<!-- elements can take the following values:                 -->
+<!--   "NONE", "UINT", "INT", "FLOAT"                        -->
+<!-- ======================================================= -->
+
+<xSCOPEconfig ioMode="basic" enabled="true">
+
+    <!-- For example: -->
+    <!-- <Probe name="I2S_RX_0" type="CONTINUOUS" datatype="INT" units="Value" enabled="true"/> -->
+
+
+    <!-- From the target code, call: xscope_int(PROBE_NAME, value); -->
+</xSCOPEconfig>

--- a/examples/app_fixed_clock/src/fixed_clock.c
+++ b/examples/app_fixed_clock/src/fixed_clock.c
@@ -1,0 +1,38 @@
+// Copyright 2026 XMOS LIMITED.
+// This Software is subject to the terms of the XMOS Public Licence: Version 1.
+
+#include <sw_pll.h>
+#include <xcore/hwtimer.h>
+#include <print.h>
+
+void fixed_clock(void)
+{
+    hwtimer_t timer = hwtimer_alloc();
+    sw_pll_result_t pll_result;
+
+    // Loop forever, cycling between 24.576 MHz and 0 Hz (disabled)
+    while(1)
+    {
+        // Enable PLL at 24.576 MHz
+        pll_result = sw_pll_fixed_clock(24576000, SW_PLL_TILE_1);
+        if (pll_result != SW_PLL_SUCCESS)
+        {
+            printstr("Error: sw_pll_fixed_clock() failed to set 24.576 MHz\r\n");
+            return;
+        }
+
+        // Wait 5 seconds
+        hwtimer_delay(timer, 5 * XS1_TIMER_MHZ * 1000000);
+
+        // Disable PLL (set to 0 Hz)
+        pll_result = sw_pll_fixed_clock(0, SW_PLL_TILE_1);
+        if (pll_result != SW_PLL_SUCCESS)
+        {
+            printstr("Error: sw_pll_fixed_clock() failed to disable PLL\r\n");
+            return;
+        }
+
+        // Wait 5 seconds
+        hwtimer_delay(timer, 5 * XS1_TIMER_MHZ * 1000000);
+    }
+}

--- a/examples/app_fixed_clock/src/main.xc
+++ b/examples/app_fixed_clock/src/main.xc
@@ -1,0 +1,16 @@
+// Copyright 2026 XMOS LIMITED.
+// This Software is subject to the terms of the XMOS Public Licence: Version 1.
+
+#include <platform.h>
+
+void fixed_clock(void);
+
+int main(void)
+{
+    par
+    {
+        on tile[1]: fixed_clock();
+    }
+
+    return 0;
+}


### PR DESCRIPTION
Added basic example showing use of sw_pll_fixed_clock(). 

This functionality was added in 2.4.0 but no example was provided. 

Updated documentation to match. 

(I had written a basic app to check functionality on xcore-400 and seemed useful enough to commit)